### PR TITLE
added cstring header for compatibility

### DIFF
--- a/star_visualizer.cxx
+++ b/star_visualizer.cxx
@@ -16,6 +16,7 @@
 #  include <GL/glut.h>
 #endif
 
+#include <cstring>
 #include <string>
 #include <queue>
 #include <fstream>


### PR DESCRIPTION
Lab machines need <cstring> to find strlen and strcmp.
